### PR TITLE
Add tests for fallback handshakes (Noise Pipes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.2.0 - May 19, 2023
+- Breaking change - renamed `set_n/3` and `get_n/2` to `set_nonce/3`
+  and `get_nonce/2` respectively
+- AEAD failure now raises a `Decibel.DecryptionError` rather than
+  a `RuntimeError`. If this is raised during a handshake, this struct 
+  will also contain any remote public keys processed during the
+  handshake, up to the point of failure
+- Added fallback tests
+- Improved documentation around Noise Pipes and connectionless
+  transports
+
+## 0.1.1 - April 25, 2023
+
+- Initial revision

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The package can be installed by adding `decibel` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:decibel, "~> 0.1.1"}
+    {:decibel, "~> 0.2.0"}
   ]
 end
 ```

--- a/lib/decibel/cipher.ex
+++ b/lib/decibel/cipher.ex
@@ -79,7 +79,7 @@ defmodule Decibel.Cipher do
         {%__MODULE__{cipher | n: n + 1}, plaintext}
 
       :error ->
-        raise "Decryption failed"
+        raise Decibel.DecryptionError
     end
   end
 end

--- a/lib/decibel/decryption_error.ex
+++ b/lib/decibel/decryption_error.ex
@@ -1,0 +1,9 @@
+defmodule Decibel.DecryptionError do
+  @moduledoc """
+  Represents a decryption failure.
+
+  If the failure occurs during the handshake phase, the `:remote_keys`
+  field will contain any remote public keys used in the handshake.
+  """
+  defexception message: "Decryption failed", remote_keys: []
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,12 +4,16 @@ defmodule Decibel.MixProject do
   def project do
     [
       app: :decibel,
-      version: "0.1.1",
+      version: "0.2.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
-      source_url: "https://github.com/ausimian/decibel"
+      source_url: "https://github.com/ausimian/decibel",
+      docs: [
+        main: "Decibel",
+        extras: ["CHANGELOG.md"]
+      ]
     ]
   end
 
@@ -38,7 +42,8 @@ defmodule Decibel.MixProject do
       description: "An Elixir implementation of the Noise Protocol Framework.",
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/ausimian/decibel"
+        "GitHub" => "https://github.com/ausimian/decibel",
+        "Noise Protocol Framework" => "https://noiseprotocol.org/index.html"
       }
     ]
   end

--- a/test/vectors/noise-c-fallback.json
+++ b/test/vectors/noise-c-fallback.json
@@ -1,0 +1,676 @@
+{
+    "vectors": [
+        {
+            "name": "Noise_XXfallback_25519_ChaChaPoly_BLAKE2s",
+            "pattern": "IK",
+            "dh": "25519",
+            "cipher": "ChaChaPoly",
+            "hash": "BLAKE2s",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+            "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+            "init_remote_static": "f215fe4ad54b354588d3fa52166179b723b9a211ec67167b9bf1729260972a23",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+            "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c7944aea61f2c1efc2d9700814dc96a8d8fba4351274cc18ef3cdf9aa8488c631200600a2e13226dabd61a6ee54f294d3275a4d760796d51f12d27c25fad320cbea15db09f78f3125d390ddc0c791f20b6387"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f144808843a40f686fb88e6c8f3bd4118270ef4b307cd0a48ccc2ae47229331d883d706fc8478163e29de1ef9d569fd272fe5c4a5f2ac29659aee6ce683df9139413948262cfc43295dfc39667b275b92d75db48"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "01b3fe36dbc8e08d4d5407b7e4aafcb6d4b670dec1a8eb50816eebf94964ea713cdc8954d82be8e24a6821dc8dd45556ab69a29474571b0d8ba936386b6a72b514ac45b8df99b8f70ba02f"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "dcf3293c98642cd2791d2c6f3232ef939d773f47b859f512dca93d"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "76414651614f48038de613c234da59c2e75bfbb5c87e33126e8e57c97fc9f721e5"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "016f26702eb62b6822c50df2ca05cd9e467d254232cfd8b497bb5e3f976aa1861bbd7e685b"
+                }
+            ],
+            "handshake_hash": "54e424c6564898d6540f925faaa56516967c1b7847f4cac83016b6d1d318288a"
+        },
+        {
+            "name": "Noise_XXfallback_25519_ChaChaPoly_BLAKE2b",
+            "pattern": "IK",
+            "dh": "25519",
+            "cipher": "ChaChaPoly",
+            "hash": "BLAKE2b",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+            "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+            "init_remote_static": "f215fe4ad54b354588d3fa52166179b723b9a211ec67167b9bf1729260972a23",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+            "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c794444c103b601479a745cc5cd1ecd456f07a5a585a145b4f0615d73bc68b751c82579de1ae62e1fcd8306ed051c75490898075cce39b302acf9860aa7f091a62712e45e9e51fba842fb2a610aba665fbba5"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f1448088437714fb2cf42a1fc018c24b3bd16731f9a1c1e476d4bd0d0ebcc53cd970d46776ce4e0dff06f00d13dcbac05019986e45929d9e70ce9f27b60ddc4b7ecbc06093bfe336d88f9fc2f0c923439b76bd3b"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "fb87f74cbf441d50f7ebe2e1cb265138de3f2070cc34a12461382ecbef625feed719f4e89385e0875a81e64228b6763b4eaf0ea4d6f0f9822534909bdcd0f5d1966f62be436195577993c7"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "a1ad6dc722186ef50b242f90f68a7c713e922f257c2739d5dfc956"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "733ad645ff63a8fc84129292f40ea7436b7277637a57b434a2d72eccf5fcaf36dc"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "5cb9704868319542e03376b53a2ca844910524e7826c4f4a8f5442a6466db486b8ec9d72b4"
+                }
+            ],
+            "handshake_hash": "9ca839672840ab3f239a4d1d7136ecde9b3cb8244c0fdc7d6c56f4e394144a54d28326d042ef30d8f253c977efce03d8f728686540672a9eac53dbf9b4c28b57"
+        },
+        {
+            "name": "Noise_XXfallback_25519_ChaChaPoly_SHA256",
+            "pattern": "IK",
+            "dh": "25519",
+            "cipher": "ChaChaPoly",
+            "hash": "SHA256",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+            "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+            "init_remote_static": "f215fe4ad54b354588d3fa52166179b723b9a211ec67167b9bf1729260972a23",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+            "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c7944a5ee5bed9cfbd66a10caecd9c3d7712389cd8b2b9d6f085cf010d25d4a8efd8088e4cf0f017e5421a790b54b870c619834ebc7c2cc0b3e94ccd34041845046332081c1bd470deb1197d20a352dedcd80"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f144808843c95caa5acaf9a7cf34254947f0d8da9233b3a4a57993c4d824696e4b1cef496cb18dd4f1769969fbb0551ee2d4b6edd0084b2a393fd6abd60235cc1b608d2df210b208d2f0eb8aea090a565d95d91e"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "1ec24f2fa67db6f7335bb7e2848571f4be76ae6702fd2123465e59e6f92f020aec4171e275fc91649d9ebedc91a507ec5bf745ec726d4ff246b6d4f460ac30e6b281174289a9ffd34722a8"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "a5bfb0ca1ccf0e51d4fb1db0b6ca2e4a7d6e8c5f99a855f9acd085"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "2b9ceb93e255064971cd959b919cc6f005563e4b23b13ebf302ceac191c753ea08"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "174007173d84dad19f968e1721b7bb68095143a4377a75d7e07f40a07f79a52deda1114224"
+                }
+            ],
+            "handshake_hash": "ecabd6cfc98cb5d46b2abdc22bf2c3e8dc97e40fc019eff2da912db4f19266c6"
+        },
+        {
+            "name": "Noise_XXfallback_25519_ChaChaPoly_SHA512",
+            "pattern": "IK",
+            "dh": "25519",
+            "cipher": "ChaChaPoly",
+            "hash": "SHA512",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+            "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+            "init_remote_static": "f215fe4ad54b354588d3fa52166179b723b9a211ec67167b9bf1729260972a23",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+            "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c79449696832c68f03dc5c478860c0b20e43546beedd2640fe3a2ae34e0bcb8c4647c1355b54c1de9435c66c5616c97259848aaebe8552de4e2b11d2e9aefb9e9e1c45984760b05fff746dc78497a202fc03a"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f1448088439b7bf2045bb041eba16516c75be8c236f1edd76124683d1abcfdf9d7117845d16d44f3cbe90f1c74265994bb4547f2817ebee6dfee7cdad411681201c4f540c948fc078c334693cd902b869be79f31"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "d75c6f5b38720f723e50a535ce5024c38f59131cf64d84d5edb6f38822c3ed2966a382934b8b9d0e1be07babed66b10e83b87cc70ae80c847a3b85c4d8be581cdd9f15eca82a13ea35de35"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "c394825f74019ec285183c85f29cbf73fb3d196d3413b183b572f1"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "5b5bca4494d23102268a964d9d33429a1f60e9cd4a27313424723bdd44a2d8c080"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "869499944f76ca0e32898c0b4148bcea144f681ef6ed6857f820eff73488fd86a29d9a25d7"
+                }
+            ],
+            "handshake_hash": "8a6cce86cce99ffcca5fa8ef912883823debb06721311b77ea64c2db7eba364d37f94f712dea812832b3515857296f028a9c8b2b5f44185b559f350a11849f82"
+        },
+        {
+            "name": "Noise_XXfallback_448_ChaChaPoly_BLAKE2s",
+            "pattern": "IK",
+            "dh": "448",
+            "cipher": "ChaChaPoly",
+            "hash": "BLAKE2s",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "34d564c4be963d1b2a89fcfe83e6a72b5e3f5e3127f9f596ffc7575e418dfc1f4e827cfc10c9fed38e92ad56ddf8f08571430df2e76d5411",
+            "init_ephemeral": "7fd26c8b8a0d5c98c85ff9ca1d7bc66d78578b9f2c4c170850748b27992767e6ea6cc9992a561c9d19dfc342e260c280ef4f3f9b8f879d4e",
+            "init_remote_static": "30abe60dab54851c91895b57fa5535d786c2144d183ff1bcf8ce245c83a22c60109b4c08fbd15da24a3884de1c914a03cb04cde8d9fc4fb1",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "a9b45971180882a79b89a3399544a425ef8136d278efa443ed67d3ff9d36e883bc330c6295bbf6ed73ff6fd10cbed767ad05ce03ebd27c7c",
+            "resp_ephemeral": "3facf7503ebee252465689f1d4e3b1dd219639ef9de4ffd6049d6d71a0f62126840febb99042421ce12af6626d98d9170260390fbc8399a5",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "6cfcb98ae6b1bc5659cadc595bf664e17094404eae6b45fde6fc40ca937d1dbe1464cb66eb21fdbaa487cd0d11d6dce5aa07b8219bfdc49a1c9fb75314a4337661ba095bea148c5a86f0655033ed028603baa2914013341a610cb722ddbde4fac7b059db3017ae6698e413efc10b3ad4f84909bd471b46011f7d6299258446a18d3ca25aa944e39b2788d12fd16fb051190c636779d20a2628f790ea12be00a0"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "f7eb9a09468f9564819de07ada77a6cf5d5eacd84682067538bf2c4e4c905e5cc35cc3ff41241e47ae3bd296477a236ef185e5a8a0f18d65a426296cf660c9ea26e3b18cda4e17641803b576f36602a4ac045cb7061a12ffd06a24bfec1d48abdd6a6f21e07219e64114809080da13d83ea58bf5c57efae0e115c10210ffef8145846fd424bd17a37caf3f2785c8fb7656978e8b521d733505758d790e5079"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "0dfdc3c05c4579fdeea20a749efe8f4928f2f758fce612a6e034c29ddd8bc036d625f3d0a3fa08643188090e6d4b516ab8c4122c0faeb9cc0932bcb80220fbd7b4792ac2de175334afbe01178e5be7e1fa47f3da3091a6bea39a95d60e1d6cfe8d2ba8"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "706eaabf3f044673be8145ec2d262604e91785d38aa569d8fd7419"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "45a4a19dfb026011088d7b1288b901fcde58fc6d4bd48c062f140a03013ca4b01a"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "b38eca8387cdd312e81aa7b0cf4741ed38c3c314bb977124ace6e6453e9f80d5fba8bcc425"
+                }
+            ],
+            "handshake_hash": "0ab5c9187ad6067d744167f5f6d9a62ed83e07e068028acf3652d78392f7df59"
+        },
+        {
+            "name": "Noise_XXfallback_448_ChaChaPoly_BLAKE2b",
+            "pattern": "IK",
+            "dh": "448",
+            "cipher": "ChaChaPoly",
+            "hash": "BLAKE2b",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "34d564c4be963d1b2a89fcfe83e6a72b5e3f5e3127f9f596ffc7575e418dfc1f4e827cfc10c9fed38e92ad56ddf8f08571430df2e76d5411",
+            "init_ephemeral": "7fd26c8b8a0d5c98c85ff9ca1d7bc66d78578b9f2c4c170850748b27992767e6ea6cc9992a561c9d19dfc342e260c280ef4f3f9b8f879d4e",
+            "init_remote_static": "30abe60dab54851c91895b57fa5535d786c2144d183ff1bcf8ce245c83a22c60109b4c08fbd15da24a3884de1c914a03cb04cde8d9fc4fb1",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "a9b45971180882a79b89a3399544a425ef8136d278efa443ed67d3ff9d36e883bc330c6295bbf6ed73ff6fd10cbed767ad05ce03ebd27c7c",
+            "resp_ephemeral": "3facf7503ebee252465689f1d4e3b1dd219639ef9de4ffd6049d6d71a0f62126840febb99042421ce12af6626d98d9170260390fbc8399a5",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "6cfcb98ae6b1bc5659cadc595bf664e17094404eae6b45fde6fc40ca937d1dbe1464cb66eb21fdbaa487cd0d11d6dce5aa07b8219bfdc49ae9aa739fe2e9c7298ce8ec029fa3494f81d0328ea3b0099f6325a5513ec5fb299e29e18f054cd8dff79709b7df4b504dc4fa18ffdc4105e6525de88d9a43f64cfa30558df80df09303e247f8b02f6df151210626442b02a7c40b6112b8eac8b5b4b535f3f9fd123f"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "f7eb9a09468f9564819de07ada77a6cf5d5eacd84682067538bf2c4e4c905e5cc35cc3ff41241e47ae3bd296477a236ef185e5a8a0f18d653fa19fe4572278a6dc212edbec10bc6455886e01f8c19f1ba5b1bb41dc274c7861610f0f0c26ba925b577001c92d81600c5e6f9def9a4d3628fd902d98228771bb08a45ce1679333a410b10507b905718ac089dfce3ad0b76ec64c58803232287d30e71d9b0e72"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "d7fd1cc6f7489dc7a825d6aeba474db8197046e9dfc4c4c6f4674805a5da53fc7132ed3d1f9e9541ef05058f949f5f255a28669c88b4ac530ac135b5abb414a51482e9a54817479334e2133841cebdd4b1ac27218afa61f0987994bc1968e820290755"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "e4968ea041d9a0f1546c65549acd8c2688241b3b8d7d99ece0585f"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "5a8829577727ecc1c1fc2abc38a1a9c5cf169706a2d0dab79655057efd111a9497"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "30f97128ab5fcaa7e6e8a8b0e6dfdbcf154f21f1882a8ae9d45a863711cef907a4ab16d455"
+                }
+            ],
+            "handshake_hash": "8a122f88d2a5af1edc736bb3030994befe0b6a70e677a98b0947eb8f5647a76f78dbebf95ec62bc70a3824c6dffb08dc76b8de859c5024497ffef09ab5c067c0"
+        },
+        {
+            "name": "Noise_XXfallback_448_ChaChaPoly_SHA256",
+            "pattern": "IK",
+            "dh": "448",
+            "cipher": "ChaChaPoly",
+            "hash": "SHA256",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "34d564c4be963d1b2a89fcfe83e6a72b5e3f5e3127f9f596ffc7575e418dfc1f4e827cfc10c9fed38e92ad56ddf8f08571430df2e76d5411",
+            "init_ephemeral": "7fd26c8b8a0d5c98c85ff9ca1d7bc66d78578b9f2c4c170850748b27992767e6ea6cc9992a561c9d19dfc342e260c280ef4f3f9b8f879d4e",
+            "init_remote_static": "30abe60dab54851c91895b57fa5535d786c2144d183ff1bcf8ce245c83a22c60109b4c08fbd15da24a3884de1c914a03cb04cde8d9fc4fb1",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "a9b45971180882a79b89a3399544a425ef8136d278efa443ed67d3ff9d36e883bc330c6295bbf6ed73ff6fd10cbed767ad05ce03ebd27c7c",
+            "resp_ephemeral": "3facf7503ebee252465689f1d4e3b1dd219639ef9de4ffd6049d6d71a0f62126840febb99042421ce12af6626d98d9170260390fbc8399a5",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "6cfcb98ae6b1bc5659cadc595bf664e17094404eae6b45fde6fc40ca937d1dbe1464cb66eb21fdbaa487cd0d11d6dce5aa07b8219bfdc49a5a72a7c68c6a6570fd7e10844fa71fd5ba92cda371022a7bc3c6246ec79fba07d1662d49e36a8ce98ae6f7e9b85588d0f11f09f357c037d701ab29281dfd2557149d81a086beb4c7124afc80edb891bf3fd20ce905c2f0c644bb39569d996241c793c3b11fedf776"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "f7eb9a09468f9564819de07ada77a6cf5d5eacd84682067538bf2c4e4c905e5cc35cc3ff41241e47ae3bd296477a236ef185e5a8a0f18d651b0102372ad56de167e274a49d635addd7f3bd09d36b35feb42489f812e502ac1d8bb3a70277ccd95fbe9d23996dd10bb2d399f6cb4ec0a99e8e6a499bda547d8711da5b54f523c4262a95c6911ab82b34f6ec06a4695918122d232b210994ebcc4bcfc52340be"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "f0426a69aa49ab91b831a30b4b1d309d3b009d2b8f7abfad8c0bb1686e1e5042dd3089a04c9bc81d3f0ae77afb366a0454d972f51463666da7c44ab634413a9edae1b3dada295f1ff8402930ae1d27c504d16b6c8421f1f22d979593226f0eb6416f19"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "14bde11b6ceb91a2b59e6f8986284a0495a3b13f33a3ba96734174"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "14b3a47bcfce7f7d6407b7e1852a359b9a19d1593e5b44e24a77322006611fea78"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "00740a8f775548a95d21bdeb8bb54358cf0f9b86b6ed1e318bdefafd684932590491d04654"
+                }
+            ],
+            "handshake_hash": "de10233028733afa576e3dcf938b94d3590151694649bbcea353358c9efae202"
+        },
+        {
+            "name": "Noise_XXfallback_448_ChaChaPoly_SHA512",
+            "pattern": "IK",
+            "dh": "448",
+            "cipher": "ChaChaPoly",
+            "hash": "SHA512",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "34d564c4be963d1b2a89fcfe83e6a72b5e3f5e3127f9f596ffc7575e418dfc1f4e827cfc10c9fed38e92ad56ddf8f08571430df2e76d5411",
+            "init_ephemeral": "7fd26c8b8a0d5c98c85ff9ca1d7bc66d78578b9f2c4c170850748b27992767e6ea6cc9992a561c9d19dfc342e260c280ef4f3f9b8f879d4e",
+            "init_remote_static": "30abe60dab54851c91895b57fa5535d786c2144d183ff1bcf8ce245c83a22c60109b4c08fbd15da24a3884de1c914a03cb04cde8d9fc4fb1",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "a9b45971180882a79b89a3399544a425ef8136d278efa443ed67d3ff9d36e883bc330c6295bbf6ed73ff6fd10cbed767ad05ce03ebd27c7c",
+            "resp_ephemeral": "3facf7503ebee252465689f1d4e3b1dd219639ef9de4ffd6049d6d71a0f62126840febb99042421ce12af6626d98d9170260390fbc8399a5",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "6cfcb98ae6b1bc5659cadc595bf664e17094404eae6b45fde6fc40ca937d1dbe1464cb66eb21fdbaa487cd0d11d6dce5aa07b8219bfdc49a4a75cb6f76dbfe3e066f3a6b17702c25d1402c885781cb9d91e22b21ea94382768fdc77013fcb85bb70065edce126e78eaf7546af3bacbee3ddbb886ce2c35e480dda812ad8666608a0af51462ae91b98a689c9cc633bf10582ef0ba6a032f7c4f608b5096c52be5"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "f7eb9a09468f9564819de07ada77a6cf5d5eacd84682067538bf2c4e4c905e5cc35cc3ff41241e47ae3bd296477a236ef185e5a8a0f18d6510dae8c52bcfd491bbaf84d6a827e2f39735d592b9f8df23ad0514f61efbcf3a1ee2718c1dc74fd2e9ff588a26067d9461b9691aab571b880915215d5c65bc891fec77ff486dbb25b48f3b1c3e10b3b4b8a712ddb71e565af64a14722f26155f6c9770f3d912d8"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "9628752df13126ce2fcd7e546521046988501097547198ac37318d2c59aa707426a08102a504573d3ee55db48cc375feb4619778fbfe81298313ea31d659d43524b30e9ad504a7ec543e2193308a4f93471eacd3248a3d4e048e61e93b080b182ee60f"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "1aa79b9afad10aaee1c89a51f50e7e7033de4e1e5f00bd4da770bb"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "72ea08603a9152ef03f9f5fd93505dc7e7089068649397414f68a06a63ae8f39d9"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "3b5dc86b673ee2521ae43e676b6b5c441f4573c42cb6c3532d2a4a023f6184dacf405959e6"
+                }
+            ],
+            "handshake_hash": "a21b7bfb5df71b1d848070c239a740556a81492587004e2958d2d02dabd99d5da36af7e270572f78f0dde2d2bbff24ff3e18a46b6dd9efc48eef7d836a4aedf8"
+        },
+        {
+            "name": "Noise_XXfallback_25519_AESGCM_BLAKE2s",
+            "pattern": "IK",
+            "dh": "25519",
+            "cipher": "AESGCM",
+            "hash": "BLAKE2s",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+            "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+            "init_remote_static": "f215fe4ad54b354588d3fa52166179b723b9a211ec67167b9bf1729260972a23",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+            "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c7944ed93427f5ee7e5dc36e2c7af485bcfda1480c4dcf85fb8ae926a0f8fb4f8b68afb0aa6610e645b04fbec834602d138e25b5ef7e9bd3ffbf1b1c260f6325d933ebf184f0d222a6bdb85f021d26da160b4"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f1448088436b7001264b33fa645d5cad525a8d5087034d53ede68f5cadaa385670a348c03ea578d5f4220cf2a43170ae4da54956fec41a8419452017121575cbbcb05921404891ab9a30ec1a2d46579a16e4e8ff"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "b598f88374aaac2dea9220750a5cb679abda62fc035b0be5c5495cb39fd031f4c57c39498a35a2ce6a667bfb3794ae4255a3e22711c68700a772907374d586149dc6f141374a1474288166"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "66b8a3a2b3c6617d3da97e82635c2120dce581e90637568aacdd10"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "31f442c4b0b10050d9973ba6dcc014c0c595da40f14005e4d7f29c05c9ff082a7c"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "8525d6cf5bde8485892af48c4ce8dcc80c5edf55d42133b8cdb2bd6c79bd77ed468617fef9"
+                }
+            ],
+            "handshake_hash": "de0e8dbbb962f0b73378bccc25a2ef40f4ec3f8b4e43baba8fcc73ba8df94484"
+        },
+        {
+            "name": "Noise_XXfallback_25519_AESGCM_BLAKE2b",
+            "pattern": "IK",
+            "dh": "25519",
+            "cipher": "AESGCM",
+            "hash": "BLAKE2b",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+            "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+            "init_remote_static": "f215fe4ad54b354588d3fa52166179b723b9a211ec67167b9bf1729260972a23",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+            "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c7944a3bec64026bf7a2212bbc71f2ae92411b8bbf4dcf1669077d7aea24eefa6346d0599b3599c0105353c1d0cb8b001aedec0d5d87c86476a5ac021cd1bbb7797fedcfdc796e8da71e9d555e54f64ba35bb"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f14480884381469e1b2a26e7264f47d96962498496bd8c3337ab6816e4f8fc32bac5f4975c4fcae5bd5c8b29a23a729bb6109a1deea2e45b4403e7a8418f399cea1b950549cab2d30dce917ef8ea32c9214eab81"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "790e1f3073ef8a3d71c807a62e0c401084c20ee9a3973a500fdf870d5aa1e20eeed6d24d7f527448e3d1d0244f2d72cdc88ebb73c85d6f299d34e9b1a56fe664446d57c0daceacf39c2d3e"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "5dbee193adc0271c3fb937332e08480993d902bcb6f2cf3d07d0dd"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "deb9b15e5eb30116b86fb8e79af7485f279c3dbcb14d53fa51abd705ec606f4ab0"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "62531f912d9e78b2360e906a5378c604cf755bdd5c7dc78f5486327c2181766f4403264781"
+                }
+            ],
+            "handshake_hash": "9a8d5d4cca5e53e3ed14f9e4e9433c98de38a66ca75ab774e482aca933c220d03107b41de066a468467a883c4e64a3840d9663cfbdf4f240b4ffe6ba72d08630"
+        },
+        {
+            "name": "Noise_XXfallback_25519_AESGCM_SHA256",
+            "pattern": "IK",
+            "dh": "25519",
+            "cipher": "AESGCM",
+            "hash": "SHA256",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+            "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+            "init_remote_static": "f215fe4ad54b354588d3fa52166179b723b9a211ec67167b9bf1729260972a23",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+            "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c7944b8d8614bb060f41b87643b3aafb8212040d88e76814403c76a78836002844f61270ba7797d441a896debf6911afadab12354107db3c9019bd97d60a87c11e917f7d6d93aa265404c8e8b83065fb8f73c"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f144808843824e059afdb8c2f7397b7b398d84a6cde4178068ad7976bd04793a16ce9d308cc9f2e8b305a36473303f9ba24d6a92d02c279ebeeab1283fe1543fce646f4b086d148d0475becd37d9cf3f2e32d862"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "8c2db1c7f7485b1c5dcc2275c19665b2aed8f0fd9dcb02944ffbbd4ea4f4553fd6a39413af97ad06e1bbb1ba65b8eafc616c6fbc51d425b1c8f4e114cb017f58286c87ab62e06f6f2f51e5"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "da246c13a9f1e6d5a18298a9970451ba151b295c7f15619ce5f7e6"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "51e0d9073c90840f503f94564574dccb5eb7055eb0b175f1972b35b6b0a1dc5a78"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "2926988f3d1036a019c5687f12e8b8c3f6b7b750013cbfb9349517355f35e318e196085154"
+                }
+            ],
+            "handshake_hash": "07c36d69147bca9eb6b2027bfe8dc6b1ebb24b50d60d99365e402164786204e3"
+        },
+        {
+            "name": "Noise_XXfallback_25519_AESGCM_SHA512",
+            "pattern": "IK",
+            "dh": "25519",
+            "cipher": "AESGCM",
+            "hash": "SHA512",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+            "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+            "init_remote_static": "f215fe4ad54b354588d3fa52166179b723b9a211ec67167b9bf1729260972a23",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+            "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c7944f550090c72302515e2be8229fca829f6fbe5e08ae6e8b948c972af4bac986ef0e6481799a93f945aee0ff21374d789625d61019c705f9e83f44d4673571701337ece1142de87b912ebe77d140f2b3614"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f144808843c6d37b52a6afef7f91a0a6f81dfda63969041193c75495b0796d5a7d390412b574dc1a7e9aead70ba9f251a3fbcc03972c9c9d2339bbc3f41fb9cae5d9bc71444f80ff0be087587cdd75414fcdd220"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "6f810ae925fcf83d38f198e3da5115206421e6dfdf4e5979a064239cd2491e934255d9f70483c56283dc65d75ab8aeb45132680f0f0a9a8fa066105e6094bff8a401c1c6e7cfb53b7a7e2c"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "bf88963de8d3f841120557881664410fccff4b8554f9389501b619"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "8b0a9f6d4e08863352eb76b039b7882fe6f6815c6d4ec66a8ad5dc8a2d4a84a274"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "93aa1992ce6fb3a89959a105acd7dbb3670d479c99f1855a30063ee9e7be3d7e2860b48ce1"
+                }
+            ],
+            "handshake_hash": "2f56227a97846c8c3ff0c780e88f5764055a0b1a24a37e2c021f79c42b09c9d2a942c3010146b615df038f0b78b1abf1623058f9ef5a468b778ee77320797fa4"
+        },
+        {
+            "name": "Noise_XXfallback_448_AESGCM_BLAKE2s",
+            "pattern": "IK",
+            "dh": "448",
+            "cipher": "AESGCM",
+            "hash": "BLAKE2s",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "34d564c4be963d1b2a89fcfe83e6a72b5e3f5e3127f9f596ffc7575e418dfc1f4e827cfc10c9fed38e92ad56ddf8f08571430df2e76d5411",
+            "init_ephemeral": "7fd26c8b8a0d5c98c85ff9ca1d7bc66d78578b9f2c4c170850748b27992767e6ea6cc9992a561c9d19dfc342e260c280ef4f3f9b8f879d4e",
+            "init_remote_static": "30abe60dab54851c91895b57fa5535d786c2144d183ff1bcf8ce245c83a22c60109b4c08fbd15da24a3884de1c914a03cb04cde8d9fc4fb1",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "a9b45971180882a79b89a3399544a425ef8136d278efa443ed67d3ff9d36e883bc330c6295bbf6ed73ff6fd10cbed767ad05ce03ebd27c7c",
+            "resp_ephemeral": "3facf7503ebee252465689f1d4e3b1dd219639ef9de4ffd6049d6d71a0f62126840febb99042421ce12af6626d98d9170260390fbc8399a5",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "6cfcb98ae6b1bc5659cadc595bf664e17094404eae6b45fde6fc40ca937d1dbe1464cb66eb21fdbaa487cd0d11d6dce5aa07b8219bfdc49a4afc65bceecf28e88c008c22c92f44934bbf061779edc7950fcde24b7d5b1e41dcc5d6c4d53d31ef14cb0c86d06fb3457ffa58a5dc3882a6bdc0a5e7e8966a1ca79de77f5ceed376575b847e14143af503acb6bf551cee8e969e860f3d50c27d8fc6d4e3f1b24c7d"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "f7eb9a09468f9564819de07ada77a6cf5d5eacd84682067538bf2c4e4c905e5cc35cc3ff41241e47ae3bd296477a236ef185e5a8a0f18d65a8034db4b52494c622dcf3cf3959ab235d8733dc123af9bdcfcbdb7186d7246589959f9c04a8082e071a5fe36f1170d6ab4932ba90918d45ef659a3869bdf7dfcb8764c1b04410307bc5b914f4dd0408ffa509338d56dfe12d0f061c93a902080a3d757c3fd161"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "90002d83461113e8c8d49f57dadac8dffa4a34d84b4673113fa03ff40a0aaf5edb182dc081f6945170c3d2df2c5f3ba4f5664a4a9ead9ae0ca551a29c446b00a75018bb54f2425e8e180489fc5412cf3588cb7cb95f4d97fdda8ce82e00a2e9736a01e"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "967cbedf1aada220cdf95092aac558a4de47ed030fade7b33c8876"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "1c4e0b75382651de7eca060dba1ac209aef73ace3d272ad7963a73c5fb08834820"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "7250a70844a039a14ff803265125277d633614226986c2887f495a7822196e70f23c84f9fc"
+                }
+            ],
+            "handshake_hash": "93d20d7b293a9fc4e9a548c95febe5a9f13e248e32f172856831712a3e56dcc7"
+        },
+        {
+            "name": "Noise_XXfallback_448_AESGCM_BLAKE2b",
+            "pattern": "IK",
+            "dh": "448",
+            "cipher": "AESGCM",
+            "hash": "BLAKE2b",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "34d564c4be963d1b2a89fcfe83e6a72b5e3f5e3127f9f596ffc7575e418dfc1f4e827cfc10c9fed38e92ad56ddf8f08571430df2e76d5411",
+            "init_ephemeral": "7fd26c8b8a0d5c98c85ff9ca1d7bc66d78578b9f2c4c170850748b27992767e6ea6cc9992a561c9d19dfc342e260c280ef4f3f9b8f879d4e",
+            "init_remote_static": "30abe60dab54851c91895b57fa5535d786c2144d183ff1bcf8ce245c83a22c60109b4c08fbd15da24a3884de1c914a03cb04cde8d9fc4fb1",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "a9b45971180882a79b89a3399544a425ef8136d278efa443ed67d3ff9d36e883bc330c6295bbf6ed73ff6fd10cbed767ad05ce03ebd27c7c",
+            "resp_ephemeral": "3facf7503ebee252465689f1d4e3b1dd219639ef9de4ffd6049d6d71a0f62126840febb99042421ce12af6626d98d9170260390fbc8399a5",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "6cfcb98ae6b1bc5659cadc595bf664e17094404eae6b45fde6fc40ca937d1dbe1464cb66eb21fdbaa487cd0d11d6dce5aa07b8219bfdc49a26e75bdc71ab2b3b22f8a143988174533bb0e978d70487cf3c6d59f42131e94bc437871c53df277f9fb104d96f2f3b0d05b4355e0b8871f35c3f582d26032e4423356e613f00b170c5e62bf3795b77585c797a2d40bbf213294b02e74e97107dc7453f0c0a126683"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "f7eb9a09468f9564819de07ada77a6cf5d5eacd84682067538bf2c4e4c905e5cc35cc3ff41241e47ae3bd296477a236ef185e5a8a0f18d65d9c4f5041102f8fc61ad53f81bf008bf9026cda540f34aa2874f60bfd22a26b7bcf4e763d795782f8fc678d944eea3e726b66620193b0606bb44a8c6e3ec4603d4fc9a8d5d8f003d30f6f82f2831bc2bcd46647282178c043217c1f9735fcd87e9d05289078113"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "009391e72d8c7e152ee634a4f99d82515983a73d9d2fd8d1e91a34339b21b42e74a78c53e7fa0506a283f543cec470b20cef9ec88ae366d9ea2eb1d3bd93e22607d5580761bac34a1e40f044106454225378fc3b8988a5f36842e3e273cf1bc6e20cf3"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "78554caa9002c25c3c89757cbe3c4e724be365070ed00a7c751f85"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "6116f2bf2cb8e46d2946987aa3108a2e752ff19c6c400707a326eec728e63be7eb"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "1f5420d664a3dafbb3212904b763e854a776204bd48e54dc1c9c02517cc6b96803d4d2b194"
+                }
+            ],
+            "handshake_hash": "0c1345204682c10d63b2c58b6a6ee117a825cd21fa1068c139fb856643b2ecf389c5643b62aac702de84b4dd8166a734180632c7f2ba6ea8b079de2c75da2263"
+        },
+        {
+            "name": "Noise_XXfallback_448_AESGCM_SHA256",
+            "pattern": "IK",
+            "dh": "448",
+            "cipher": "AESGCM",
+            "hash": "SHA256",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "34d564c4be963d1b2a89fcfe83e6a72b5e3f5e3127f9f596ffc7575e418dfc1f4e827cfc10c9fed38e92ad56ddf8f08571430df2e76d5411",
+            "init_ephemeral": "7fd26c8b8a0d5c98c85ff9ca1d7bc66d78578b9f2c4c170850748b27992767e6ea6cc9992a561c9d19dfc342e260c280ef4f3f9b8f879d4e",
+            "init_remote_static": "30abe60dab54851c91895b57fa5535d786c2144d183ff1bcf8ce245c83a22c60109b4c08fbd15da24a3884de1c914a03cb04cde8d9fc4fb1",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "a9b45971180882a79b89a3399544a425ef8136d278efa443ed67d3ff9d36e883bc330c6295bbf6ed73ff6fd10cbed767ad05ce03ebd27c7c",
+            "resp_ephemeral": "3facf7503ebee252465689f1d4e3b1dd219639ef9de4ffd6049d6d71a0f62126840febb99042421ce12af6626d98d9170260390fbc8399a5",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "6cfcb98ae6b1bc5659cadc595bf664e17094404eae6b45fde6fc40ca937d1dbe1464cb66eb21fdbaa487cd0d11d6dce5aa07b8219bfdc49a8e3dc70856f83026092cf98287fe6227302514a249360e503cad31a177769cd23bebd2677f327354a8103032fc29eba6c1471f7462713b558232a1d2a6bda1676947d68fa36cd1c971769223f9d3fe766aaa4f3d8fe2a7be13b9f243dcd3674ce0a2b4cc43ee66ea"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "f7eb9a09468f9564819de07ada77a6cf5d5eacd84682067538bf2c4e4c905e5cc35cc3ff41241e47ae3bd296477a236ef185e5a8a0f18d65e3f5dd1bd99e586a596897316cca001974f992be11b428efb07efa43e9d13a8e9855d3261d405e10fda71c009f421c52824453c6131d6dca0142100165b3c277de879fb8488a76fbf20bb35d5b1450c76889efa2083d6846cfe4fb122d27e5af7a2af381f03910"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "443600bc473f16d344ebdf4176af9e0b9616a900c881630eb421712872eb366643bf0bf07c2b38ad01482ee2fcd700efb63deda41599ed267f98941364bcc3497ca2cda57d6268328ec856f4b085a8e85a9f95802f7f52dd72d87066645a640d40f347"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "f1a6ea28b0a900a4846148ec91715dc2e2dd6063588652380fca42"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "1a96e14c139da0b3d149f44e696ba02e8f1eb9ff5d8eeac4c83ebbabd6e9d6f239"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "720a621e4a7d2a089dd10be48bf8a227e8e63beb7ec8363203f507a5a44033f6b660c70e7b"
+                }
+            ],
+            "handshake_hash": "1e076ced4d3be04fe743b451a9ccda8278807e47a2e4d239e3014fa385781d05"
+        },
+        {
+            "name": "Noise_XXfallback_448_AESGCM_SHA512",
+            "pattern": "IK",
+            "dh": "448",
+            "cipher": "AESGCM",
+            "hash": "SHA512",
+            "fallback": true,
+            "init_prologue": "50726f6c6f677565313233",
+            "init_static": "34d564c4be963d1b2a89fcfe83e6a72b5e3f5e3127f9f596ffc7575e418dfc1f4e827cfc10c9fed38e92ad56ddf8f08571430df2e76d5411",
+            "init_ephemeral": "7fd26c8b8a0d5c98c85ff9ca1d7bc66d78578b9f2c4c170850748b27992767e6ea6cc9992a561c9d19dfc342e260c280ef4f3f9b8f879d4e",
+            "init_remote_static": "30abe60dab54851c91895b57fa5535d786c2144d183ff1bcf8ce245c83a22c60109b4c08fbd15da24a3884de1c914a03cb04cde8d9fc4fb1",
+            "resp_prologue": "50726f6c6f677565313233",
+            "resp_static": "a9b45971180882a79b89a3399544a425ef8136d278efa443ed67d3ff9d36e883bc330c6295bbf6ed73ff6fd10cbed767ad05ce03ebd27c7c",
+            "resp_ephemeral": "3facf7503ebee252465689f1d4e3b1dd219639ef9de4ffd6049d6d71a0f62126840febb99042421ce12af6626d98d9170260390fbc8399a5",
+            "messages": [
+                {
+                    "payload": "4c756477696720766f6e204d69736573",
+                    "ciphertext": "6cfcb98ae6b1bc5659cadc595bf664e17094404eae6b45fde6fc40ca937d1dbe1464cb66eb21fdbaa487cd0d11d6dce5aa07b8219bfdc49a9148a3350a7891935e87995a4103402d4082dab0ab7869e2fea0cbb45b36666ba7f15ef86598df3b2db31381bf8a8f26804b55892b07250d64e9e0f9c12682dd53b8da8a749c31e4b04c0d504835bed2c56895ab9ec1f68eb89f6227a704177d69dc61910d6f5cd2"
+                },
+                {
+                    "payload": "4d757272617920526f746862617264",
+                    "ciphertext": "f7eb9a09468f9564819de07ada77a6cf5d5eacd84682067538bf2c4e4c905e5cc35cc3ff41241e47ae3bd296477a236ef185e5a8a0f18d65645347c821c27893547aae940c92b5b85b31190ea4f57df58fdc3dfb80478e521940a94e900568559ee5a586f188111196f66e1945995caff575f967aba0fa30dccf9b3e4457b9d99ad8831013e6eb4eca0adfd6c494eb5ad3625025dffd0bd47de9c9015f6b1d"
+                },
+                {
+                    "payload": "462e20412e20486179656b",
+                    "ciphertext": "d1a8f8f2615c14e7d637245c97f48b8a3b77fd99ffaec67d76159e611bdeb32c9a6f1f70c2fdc951ff716e27aec30a9d219a750d91f667224594f3e063d035ba5480290b2c2c1444fb05d3494e3eb7387036caf21b9391786f81c1e44b3116bb418319"
+                },
+                {
+                    "payload": "4361726c204d656e676572",
+                    "ciphertext": "31c604954fcf9d8a820185e4328b244ca4a40ed91c62bd0f2d1cc9"
+                },
+                {
+                    "payload": "4a65616e2d426170746973746520536179",
+                    "ciphertext": "0264062f800efa60ca039b068c5f0d5337aaafd187a4e386dc55c8f683981558b9"
+                },
+                {
+                    "payload": "457567656e2042f6686d20766f6e2042617765726b",
+                    "ciphertext": "d712278e43763a32cb64f237d223c306d2d65aaa0bccd90cfe0d20ef7606417092c757bd5d"
+                }
+            ],
+            "handshake_hash": "16725e642cacffdf4c8ce31e5c87323ee2b7783ce690cf2ef3c038fe604041bc65fa2bd331a079c7b920b981294d61c0bfceaf531e50870b46dc9d9fa66a3261"
+        }
+    ]
+}


### PR DESCRIPTION
Introduce an explicit DecryptionError, raised if AEAD decryption fails. If this error is raised during a handshake, any remote public keys (including those transmitted prior to the handshake failure) are available in the error. This allows Decibel to support 'Noise Pipes'.

Added fallback tests from the `noise-c` test suite.

Renamed set_n/get_n to set_nonce/get-nonce